### PR TITLE
Implement number of interfaces metrics

### DIFF
--- a/.log.txt
+++ b/.log.txt
@@ -1,1 +1,0 @@
-[ReferenceType(arguments=None, dimensions=[], name=Base, sub_type=None)]

--- a/.log.txt
+++ b/.log.txt
@@ -1,0 +1,1 @@
+[ReferenceType(arguments=None, dimensions=[], name=Base, sub_type=None)]

--- a/metrics/ast_metrics.py
+++ b/metrics/ast_metrics.py
@@ -120,6 +120,15 @@ def ncss(parser_class) -> int:
     return value
 
 
+def impls(tlist) -> int:
+    """
+    Count the number of interfaces the class implements.
+
+    r:type: int
+    """
+    return len(tlist[0][1].implements or [])
+
+
 if __name__ == '__main__':
     java = sys.argv[1]
     metrics = sys.argv[2]
@@ -143,6 +152,8 @@ if __name__ == '__main__':
                              f'Number of Static Methods\n')
                 metric.write(f'ncss {ncss(raw)}: '
                              f'Non Commenting Source Statements (NCSS)\n')
+                metric.write(f'impls {impls(tree_class)}: '
+                             f'Number of implemented interfaces \n')
         except FileNotFoundError as exception:
             message = f"{type(exception).__name__} {str(exception)}: {java}"
             sys.exit(message)


### PR DESCRIPTION
Hey. I have found an easy way to collect metrics of number of interfaces class implements (Issue #12), as `tree_class` object has an attribute `implements` with a list of names of these interfaces (or `None` if no such exist). 