### PR TITLE
Fix `octokit` not found error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ env:
 	fi
 	flake8 --version
 	pylint --version
+	gem install octokit -v 4.21.0
 
 # Get the list of repos from GitHub and then create directories
 # for them. Each dir will be empty.


### PR DESCRIPTION
Every time I built the container, I needed to do this manually in interactive mode and save the image as another container.
https://github.com/yegor256/cam/issues/27#issuecomment-1043405686