### PR TITLE
Add `jpeek` support, fix bugs 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+dataset
+dataset/**/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get -y update && apt-get install -y cloc shellcheck
 RUN gem install texsc
 RUN gem install texqc
 RUN apt-get install -y aspell
+RUN apt-get install -y xmlstarlet
 
 RUN tlmgr --verify-repo=none update --self
 RUN tlmgr --verify-repo=none install href-ul huawei ffcode latexmk fmtcount trimspaces libertine paralist makecell footmisc currfile enumitem wrapfig lastpage biblatex titling svg catchfile transparent textpos fvextra xstring framed environ iexec anyfontsize changepage titlesec
@@ -52,3 +53,14 @@ RUN cd /usr/local && \
   rm pmd-bin-6.37.0.zip && \
   mv pmd-bin-6.37.0 pmd && \
   ln -s /usr/local/pmd/bin/run.sh /usr/local/bin/pmd
+
+#install Gradle
+RUN wget -q https://services.gradle.org/distributions/gradle-7.4-bin.zip \
+    && unzip gradle-7.4-bin.zip -d /opt \
+    && rm gradle-7.4-bin.zip
+
+RUN wget https://repo1.maven.org/maven2/org/jpeek/jpeek/0.30.25/jpeek-0.30.25-jar-with-dependencies.jar \
+    && mv jpeek-0.30.25-jar-with-dependencies.jar /opt/app
+# Set Gradle in the environment variables
+ENV GRADLE_HOME /opt/gradle-7.4
+ENV PATH $PATH:/opt/gradle-7.4/bin

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ jpeek: $(TARGET)/repositories.csv $(TARGET)/github
 							then
 						  		echo "$${package}/$${class}: $${value}"
 								mkdir -p "$$(dirname $${mfile})"
-								echo "$${name}$${suffix} $${value} $${description}" >> "$${mfile}"
+								echo "$${name}$${suffix} $${value} $${name}" >> "$${mfile}"
 								lastm="$${mfile}"
 							else
 								echo "$${package}/$${class}: can't find corresponding file"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ TOTAL = 1
 # GitHub auth token
 TOKEN =
 
-all: env lint $(TARGET)/start.txt $(TARGET)/repositories.csv cleanup clone filter measure aggregate zip
+all: env lint $(TARGET)/start.txt $(TARGET)/repositories.csv cleanup clone jpeek filter measure aggregate zip
 
 # Record the moment in time, when processing started.
 $(TARGET)/start.txt: $(TARGET)/temp
@@ -85,6 +85,7 @@ env:
 	fi
 	flake8 --version
 	pylint --version
+	gem install octokit -v 4.21.0
 
 # Get the list of repos from GitHub and then create directories
 # for them. Each dir will be empty.
@@ -123,6 +124,13 @@ clone: $(TARGET)/repositories.csv $(TARGET)/github
 			printf "$${r},$$(git --git-dir "$(TARGET)/github/$${r}/.git" rev-parse HEAD)\n" >> "$(TARGET)/hashes.csv"
 	  	fi
 	done < "$(TARGET)/repositories.csv"
+
+# Run jpeek for the entire repo.
+jpeek: $(TARGET)/repositories.csv $(TARGET)/github
+	echo "Jpeek'ing..."
+	for d in $$(find "$(TARGET)/github" -maxdepth 2 -mindepth 2 -type d -print); do
+
+	done
 
 # Apply filters to all found repositories at once.
 filter: $(TARGET)/github $(TARGET)/temp

--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,18 @@ clone: $(TARGET)/repositories.csv $(TARGET)/github
 # Try to build classes and run jpeek for the entire repo.
 jpeek: $(TARGET)/repositories.csv $(TARGET)/github
 	echo "Jpeek'ing..."
-	for project in $$(find "$(TARGET)/github" -maxdepth 3 -mindepth 2 -type d -print); do
-		echo "Project: $${project}"
-		if [ -e "$${project}/build.gradle" ]; then
+	for project in $$(find "$(TARGET)/github" -depth -maxdepth 4 -mindepth 2 -type d -print); do
+		echo "Building project: $${project}"
+		if [ -e "$${project}/gradlew" ]; then
+			echo "Using gradlew"
+			$${project}/gradlew classes -p "$${project}"
+		elif [ -e "$${project}/build.gradle" ]; then
+			echo "Using build.gradle"
 			echo "apply plugin: 'java'" >> "$${d}/build.gradle"
 			gradle classes -p "$${project}"
 		elif [ -e "$${project}/pom.xml" ]; then
-			mvn compiler:compile -f "$${project}" -U
+			echo "Using mvn install"
+			mvn compiler:compile -Dmaven.test.skip=true -f "$${project}" -U
 		else
 			echo "Could not build classes (not maven nor gradle project)..."
 			continue

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ TOTAL = 1
 # GitHub auth token
 TOKEN =
 
+# Path to repositories names joined by newlines to take from
+REPOS =
+
 all: env lint $(TARGET)/start.txt $(TARGET)/repositories.csv cleanup clone jpeek filter measure aggregate zip
 
 # Record the moment in time, when processing started.
@@ -91,8 +94,16 @@ env:
 # Get the list of repos from GitHub and then create directories
 # for them. Each dir will be empty.
 $(TARGET)/repositories.csv: $(TARGET)/temp
-	$(RUBY) discover-repos.rb --token=$(TOKEN) --total=$(TOTAL) "--path=$(TARGET)/repositories.csv" "--tex=$(TARGET)/temp/repo-details.tex"
-	cat "$(TARGET)/repositories.csv"
+	csv="$(TARGET)/repositories.csv"
+	if [ test -z "$(REPOS)" ] || [ ! -e "$(REPOS)" ];
+	then
+		echo "Using discover-repos.rb..."
+		$(RUBY) discover-repos.rb --token=$(TOKEN) --total=$(TOTAL) "--path=$${csv}" "--tex=$(TARGET)/temp/repo-details.tex"
+	else
+		echo "Using repos list of csv..."
+		cat "$(REPOS)" >> "$${csv}"
+	fi
+	cat "$${csv}"
 
 # Delete directories that don't exist in the list of
 # required repositories.

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ aggregate: $(TARGET)/measurements $(TARGET)/data
 				if [ -e "$${m}.$${a}" ]; then
 					printf ",$$(cat "$${m}.$${a}")" >> "$${csv}"
 				else
-					printf '-' >> "$${csv}"
+					printf ',-' >> "$${csv}"
 				fi
 			done
 			printf "\n" >> "$${csv}"

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ clone: $(TARGET)/repositories.csv $(TARGET)/github
 	while IFS= read -r r; do
 	  	if [ -e "$(TARGET)/github/$${r}/.git" ]; then
 	    	echo "$${r}: Git repo is already here"
+			git reset --hard
 	  	else
 	    	echo "$${r}: trying to clone it..."
 	    	git clone --depth 1 "https://github.com/$${r}" "$(TARGET)/github/$${r}"

--- a/discover-repos.rb
+++ b/discover-repos.rb
@@ -59,7 +59,9 @@ puts "Will fetch #{pages} GitHub pages"
       'language:java',
       'is:public',
       'mirror:false',
-      'archived:false'
+      'archived:false',
+      'NOT',
+      'android'
     ].join(' '),
     per_page: size,
     page: p

--- a/discover-repos.rb
+++ b/discover-repos.rb
@@ -31,8 +31,8 @@ opts = Slop.parse do |o|
   o.string '--token', 'GitHub access token', default: ''
   o.integer '--total', 'Total number of repos to take from GitHub', required: true
   o.integer '--min-stars', 'Minimum GitHub stars in each repo', default: 1000
-  o.integer '--max-stars', 'Maximum GitHub stars in each repo', default: 10000
-  o.integer '--min-size', 'Minimum size of GitHub repo, in Kb', default: 200
+  o.integer '--max-stars', 'Maximum GitHub stars in each repo', default: 100000
+  o.integer '--min-size', 'Minimum size of GitHub repo, in Kb', default: 100
   o.string '--path', 'The file name to save the list to', required: true
   o.string '--tex', 'The file name to save LaTeX summary of the operation', required: true
   o.on '--help' do

--- a/discover-repos.rb
+++ b/discover-repos.rb
@@ -54,8 +54,7 @@ puts "Will fetch #{pages} GitHub pages"
 (0..pages - 1).each do |p|
   json = github.search_repositories(
     [
-      "stars:>=#{opts['min-stars']}",
-      "stars:<=#{opts['max-stars']}",
+      "stars:#{opts['min-stars']}..#{opts['max-stars']}",
       "size:>=#{opts['min-size']}",
       'language:java',
       'is:public',

--- a/metrics/ast_metrics.py
+++ b/metrics/ast_metrics.py
@@ -140,19 +140,19 @@ if __name__ == '__main__':
             if not tree_class:
                 raise Exception('This is not a class')
             with open(metrics, 'a') as metric:
-                metric.write(f'attributes {attrs(tree_class)}: '
+                metric.write(f'attributes {attrs(tree_class)} '
                              f'Number of Non-Static Attributes\n')
-                metric.write(f'sattributes {sattrs(tree_class)}: '
+                metric.write(f'sattributes {sattrs(tree_class)} '
                              f'Number of Static Attributes\n')
-                metric.write(f'ctors {ctors(tree_class)}: '
+                metric.write(f'ctors {ctors(tree_class)} '
                              f'Number of Constructors\n')
-                metric.write(f'methods {methods(tree_class)}: '
+                metric.write(f'methods {methods(tree_class)} '
                              f'Number of Non-Static Methods\n')
-                metric.write(f'smethods {smethods(tree_class)}: '
+                metric.write(f'smethods {smethods(tree_class)} '
                              f'Number of Static Methods\n')
-                metric.write(f'ncss {ncss(raw)}: '
+                metric.write(f'ncss {ncss(raw)} '
                              f'Non Commenting Source Statements (NCSS)\n')
-                metric.write(f'impls {impls(tree_class)}: '
+                metric.write(f'impls {impls(tree_class)} '
                              f'Number of implemented interfaces \n')
         except FileNotFoundError as exception:
             message = f"{type(exception).__name__} {str(exception)}: {java}"

--- a/metrics/authors.py
+++ b/metrics/authors.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
 
     try:
         with open(metrics, 'a', encoding='utf-8') as metric:
-            metric.write(f'authors {noca(java)}: '
+            metric.write(f'authors {noca(java)} '
                          f'Number of Committers/Authors\n')
     except FileNotFoundError as exception:
         message: str = f"{type(exception).__name__} {str(exception)}: {java}"

--- a/metrics/cyclomatic_complexity.py
+++ b/metrics/cyclomatic_complexity.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
             for path, node in ast:
                 complexity += branches(node)
             with open(metrics, 'a') as m:
-                m.write(f'cc {complexity}: Cyclomatic Complexity\n')
+                m.write(f'cc {complexity} Cyclomatic Complexity\n')
         except FileNotFoundError as exception:
             message = f"{type(exception).__name__} {str(exception)}: {java}"
             sys.exit(message)

--- a/metrics/jpeek.sh
+++ b/metrics/jpeek.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# The MIT License (MIT)
+#
+# Copyright (c) 2021-2022 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -e
+set -o pipefail
+
+java=$1
+output=$2
+
+sample="MMAC NaN Method-Method through Attributes Cohesion. The MMAC is the average cohesion of all pairs of methods. In simple words this metric shows how many methods have the same parameters or return types. When class has some number of methods and most of them operate the same parameters it assumes better. It looks like class contains overloaded methods. Preferably when class has only one method with parameters and/or return type and it assumes that class do only one thing. Value of MMAC metric is better for these one classes. Metric value is in interval [0, 1]. Value closer to 1 is better.
+CAMC NaN The Cohesion Among Methods in Class (CAMC) measures the extent of intersections of individual method parameter type lists with the parameter type list of all methods in the class.
+NHD NaN The NHD (Normalized Hamming Distance) class cohesion metric is based on the \"Hamming distance\" from information theory. Here, we measure the similarity in all methods of a class in terms of the types of their arguments. A class in which all methods accept the same set of types of parameters is said to be in \"perfect parameter agreement\" (NHD score \"1\"), whereas a class in which all methods accept unique parameter types not shared by others has no parameter agreement (NHD score \"0\").
+LCOM5 NaN 'LCOM5' is a 1996 revision by B. Henderson-Sellers, L. L. Constantine, and I. M. Graham, of the initial LCOM metric proposed by MIT researchers. The values for LCOM5 are defined in the real interval [0, 1] where '0' describes \"perfect cohesion\" and '1' describes \"no cohesion\". Two problems with the original definition are addressed: a) LCOM5 has the ability to give values across the full range and no specific value has a higher probability of attainment than any other (the original LCOM has a preference towards the value \"0\") b) Following on from the previous point, the values can be uniquely interpreted in terms of cohesion, suggesting that they be treated as percentages of the \"no cohesion\" score '1'
+SCOM NaN \"Sensitive Class Cohesion Metric\" (SCOM) notes some deficits in the LCOM5 metric, particularly how it fails in some cases to discriminate (ie. it assigns the same score) between classes where one is clearly more cohesive than the other. In these cases, SCOM is more \"sensitive\" than LCOM5 because it evaluates to different values. Like LCOM5, SCOM values lie in the range [0..1], but their meanings are inverted: \"0\" indicates no cohesion at all (i.e. every method deals with an independent set of attributes), whereas \"1\" indicates full cohesion (ie. every method uses all the attributes of the class). This inversion stems from SCOM measuring how much \"agreement\" there is among the methods, unlike LCOM which measures how much \"disagreement\" there is. Another important distinction is that SCOM assigns \"weights\" to each pair of methods computed equal to the proportion of total attributes being used between the two. This contributes to the metric's \"sensitivity\". Finally, the authors provide a formula for the minimum value beyond which \"we can claim that [the class] has at least two clusters and it must be subdivided into smaller, more cohesive classes\".
+MMAC(cvc) NaN Same as MMAC, but in this case, the constructors are excluded from the metric formulas.
+CAMC(cvc) NaN Same as CAMC, but in this case, the constructors are excluded from the metric formulas.
+NHD(cvc) NaN Same as NHD, but in this case, the constructors are excluded from the metric formulas.
+LCOM5(cvc) NaN Same as LCOM5, but in this case, the constructors are excluded from the metric formulas.
+SCOM(cvc) NaN Same as SCOM, but in this case, the constructors are excluded from the metric formulas."
+
+file="${java//github/jpeek}"
+out=""
+if [ "${file}" != "${java}" ]; then
+	out="$(cat "${file}")"
+else
+	out="${sample}"
+fi
+
+cat <<EOT> "${output}"
+${out}
+EOT


### PR DESCRIPTION
- Adds Jpeek calculation for `CaM`
- Jpeek uses .class files, so there's need to compile projects -> adds default mvn, gradle, gradlew builds
- `Jpeek` is a target in Makefile, so can be just disabled. 
- Fixes csv formatting errors
- Fixes `discover-rebos.rb` error with stars range  
- Adds custom repos list support via `-e "REPOS=/path/to/list"` option