### PR TITLE
Implement average number of parts in variable names metric

### DIFF
--- a/metrics/ast.py
+++ b/metrics/ast.py
@@ -170,8 +170,8 @@ class NotClassError(Exception):
 
 
 if __name__ == '__main__':
-    JAVA = "Server.java"
-    METRICS = "metr"
+    JAVA = sys.argv[1]
+    METRICS = sys.argv[2]
     with open(JAVA, encoding='utf-8', errors='ignore') as file:
         try:
             raw = javalang.parse.parse(file.read())

--- a/metrics/ast.py
+++ b/metrics/ast.py
@@ -145,17 +145,18 @@ def annts(tlist) -> int:
     """
     return len(tlist[0][1].annotations or [])
 
-def varcomp(parser_class) -> int:
+
+def varcomp(tlist) -> int:
     """Return average number of parts in variable names in class.
     r:type: int
     """
     sum, count = 0, 0
-    for path, node in parser_class:
-        del path
-        node_type = str(type(node.name))
-        if node_type == 'VariableDeclarator':
+    for _, node in tlist[0][1].filter(javalang.tree.VariableDeclarator):
+        name = node.name
+        if name != "":
             count += 1
-            for letter in node.name:
+            sum += 1
+            for letter in name[1:]:
                 if letter == letter.upper():
                     sum += 1
 
@@ -163,13 +164,14 @@ def varcomp(parser_class) -> int:
         return 0
     return sum / count
 
+
 class NotClassError(Exception):
     """If it's not a class"""
 
 
 if __name__ == '__main__':
-    JAVA = sys.argv[1]
-    METRICS = sys.argv[2]
+    JAVA = "Server.java"
+    METRICS = "metr"
     with open(JAVA, encoding='utf-8', errors='ignore') as file:
         try:
             raw = javalang.parse.parse(file.read())
@@ -199,7 +201,7 @@ if __name__ == '__main__':
                              f'Class is Final\n')
                 metric.write(f'noca {annts(tree_class)} '
                              f'Number of Class Annotations\n')
-                metric.write(f'varcomp {varcomp(raw)} '
+                metric.write(f'varcomp {varcomp(tree_class)} '
                              f'Average number of parts in variable names\n')
         except FileNotFoundError as exception:
             message = f"{type(exception).__name__} {str(exception)}: {JAVA}"

--- a/metrics/ast.py
+++ b/metrics/ast.py
@@ -145,6 +145,23 @@ def annts(tlist) -> int:
     """
     return len(tlist[0][1].annotations or [])
 
+def varcomp(parser_class) -> int:
+    """Return average number of parts in variable names in class.
+    r:type: int
+    """
+    sum, count = 0, 0
+    for path, node in parser_class:
+        del path
+        node_type = str(type(node.name))
+        if node_type == 'VariableDeclarator':
+            count += 1
+            for letter in node.name:
+                if letter == letter.upper():
+                    sum += 1
+
+    if count == 0:
+        return 0
+    return sum / count
 
 class NotClassError(Exception):
     """If it's not a class"""
@@ -182,6 +199,8 @@ if __name__ == '__main__':
                              f'Class is Final\n')
                 metric.write(f'noca {annts(tree_class)} '
                              f'Number of Class Annotations\n')
+                metric.write(f'varcomp {varcomp(raw)} '
+                             f'Average number of parts in variable names\n')
         except FileNotFoundError as exception:
             message = f"{type(exception).__name__} {str(exception)}: {JAVA}"
             sys.exit(message)

--- a/metrics/ast.py
+++ b/metrics/ast.py
@@ -150,19 +150,18 @@ def varcomp(tlist) -> float:
     """Return average number of parts in variable names in class.
     r:type: float
     """
-    sum, count = 0, 0
+    parts, variables = 0, 0
     for _, node in tlist[0][1].filter(javalang.tree.VariableDeclarator):
-        name = node.name
-        if name != "":
-            count += 1
-            sum += 1
+        if (name := node.name) != '':
+            variables += 1
+            parts += 1
             for letter in name[1:]:
                 if letter == letter.upper():
-                    sum += 1
+                    parts += 1
 
-    if count == 0:
+    if variables == 0:
         return 0
-    return sum / count
+    return parts / variables
 
 
 class NotClassError(Exception):

--- a/metrics/ast.py
+++ b/metrics/ast.py
@@ -146,9 +146,9 @@ def annts(tlist) -> int:
     return len(tlist[0][1].annotations or [])
 
 
-def varcomp(tlist) -> int:
+def varcomp(tlist) -> float:
     """Return average number of parts in variable names in class.
-    r:type: int
+    r:type: float
     """
     sum, count = 0, 0
     for _, node in tlist[0][1].filter(javalang.tree.VariableDeclarator):

--- a/tests/metrics/test-ast.sh
+++ b/tests/metrics/test-ast.sh
@@ -43,5 +43,6 @@ stdout=$2
     grep "notp 1" "${temp}/stdout"
     grep "final 1" "${temp}/stdout"
     grep "noca 1" "${temp}/stdout"
+    grep "varcomp 1.0" "${temp}/stdout"
 } > "${stdout}" 2>&1
 echo "👍🏻 Correctly collected AST metrics"

--- a/tests/steps/test-measure-file.sh
+++ b/tests/steps/test-measure-file.sh
@@ -44,7 +44,7 @@ EOT
     echo "${msg}"
     test "$(echo "${msg}" | grep -c "sum=0")" = 0
     all=$(find "${temp}" -name 'm.*' -type f -exec basename {} \;)
-    test "$(echo "${all}" | wc -l | xargs)" = "35"
+    test "$(echo "${all}" | wc -l | xargs)" = "36"
     echo "${all}" | sort | while IFS= read -r m; do
         metric=${m//m\./}
         echo "${metric}: $(cat "${temp}/${m}")"


### PR DESCRIPTION
We take the number of parts of the name of each variable in the class and calculate their arithmetic mean. Parts of names are counted according to the naming styles camelCase and PascalCase. Abbreviations are considered separate words.

This metric is necessary for the study of compound variable names.