### PR TITLE
Improve `varcomp` metric calculation

### DIFF
--- a/metrics/ast.py
+++ b/metrics/ast.py
@@ -310,7 +310,7 @@ def varcomp(tlist) -> float:
         variables += 1
 
         # Java only allows "$" and "_" as special symbols in variable names.
-        # Split by them to only count words ans numbers.
+        # Split variable name by them to only count words and numbers.
         components = [comp for comp in re.split(r'[\$_]+', name) if comp != '']
 
         if len(components) == 0:

--- a/tests/metrics/test-ast.sh
+++ b/tests/metrics/test-ast.sh
@@ -31,20 +31,24 @@ stdout=$2
     echo "@Demo public final class Foo<T> extends Bar implements Boom, Hello {
         final File a;
         static String Z;
+        static float MY_CONSTANT_PI_WITH_LONG_NAME = 3.14159;
+        private int camelCase123;
         void x() { }
         int y() { return 0; }
+        void camelCaseMethod() { }
     }" > "${java}"
     "${LOCAL}/metrics/ast.py" "${java}" "${temp}/stdout"
     cat "${temp}/stdout"
-    grep "nooa 1" "${temp}/stdout"
+    grep "nooa 2" "${temp}/stdout"
+    grep "nosa 2" "${temp}/stdout"
     grep "noca 1" "${temp}/stdout"
-    grep "noom 2" "${temp}/stdout"
+    grep "noom 3" "${temp}/stdout"
     grep "noii 2" "${temp}/stdout"
     grep "napc 1" "${temp}/stdout"
     grep "notp 1" "${temp}/stdout"
     grep "final 1" "${temp}/stdout"
     grep "noca 1" "${temp}/stdout"
-    grep "varcomp 1.0" "${temp}/stdout"
+    grep "varcomp 2.75" "${temp}/stdout"
     grep "mhf 1.0" "${temp}/stdout"
     grep "smhf 0" "${temp}/stdout"
     grep "ahf 0" "${temp}/stdout"


### PR DESCRIPTION
This PR updates the `varcomp` metric computation algorithm to properly handle variable names in different styles. It also updates the corresponding test case.

Here are some examples that demonstrate how the calculations of the parts in the variable names have been changed:

```
Variable name                 | Old | New |
------------------------------+-----+-----+
z                             |  1  |  1  |
x                             |  1  |  1  |
someVar                       |  2  |  2  |
$name                         |  1  |  1  |
_private_variable             |  2  |  2  |
SOME_CONSTANT_WITH_LONG_NAME  |  28 |  5  |
hello123                      |  4  |  2  |
first_second                  |  2  |  2  |
helloWorld                    |  2  |  2  |
TESTNAME                      |  8  |  1  |
parseURLFromName              |  6  |  3  |
```

Closes #132.