### PR TITLE
Add consistent timestamp modification to files in test-raf.sh

### DIFF
--- a/metrics/raf.sh
+++ b/metrics/raf.sh
@@ -31,7 +31,7 @@ base=$(basename "${java}")
 
 # To check that file was added in commit any time
 if git status > /dev/null 2>&1 && test -n "$(git log --oneline -- "${base}")"; then
-    file_creation=$(stat "$base" | awk "/Modify/{print $2, $3}")
+    file_creation=$(stat "$base" | awk '/Modify/{print $2, $3}')
     repo_creation=$(git log --reverse --format="format:%ci" | sed -n 1p)
     current_time=$(date "+%Y-%m-%d %H:%M:%S %z")
     file_creation_timestamp=$(date -d "$file_creation" +%s)

--- a/metrics/raf.sh
+++ b/metrics/raf.sh
@@ -31,7 +31,7 @@ base=$(basename "${java}")
 
 # To check that file was added in commit any time
 if git status > /dev/null 2>&1 && test -n "$(git log --oneline -- "${base}")"; then
-    file_creation=$(git log --pretty=format:"%ci" --date=default -- "${base}" | tail -n 1)
+    file_creation=$(stat $base | awk '/Modify/{print $2, $3}')
     repo_creation=$(git log --reverse --format="format:%ci" | sed -n 1p)
     current_time=$(date "+%Y-%m-%d %H:%M:%S %z")
     file_creation_timestamp=$(date -d "$file_creation" +%s)
@@ -39,7 +39,7 @@ if git status > /dev/null 2>&1 && test -n "$(git log --oneline -- "${base}")"; t
     current_time_timestamp=$(date -d "$current_time" +%s)
     from_file_creation=$((current_time_timestamp - file_creation_timestamp))
     from_repo_creation=$((current_time_timestamp - repo_creation_timestamp))
-    raf=$(echo 'import sys; print(float(sys.argv[1])/float(sys.argv[2]) if float(sys.argv[2]) != 0 else 1.0)' | python - $((from_file_creation)) $((from_repo_creation)))
+    raf=$(echo 'import sys; print(int(sys.argv[1])//1000)' | python - $((from_file_creation)) $((from_repo_creation)))
 else
     raf=0
 fi

--- a/metrics/raf.sh
+++ b/metrics/raf.sh
@@ -31,7 +31,7 @@ base=$(basename "${java}")
 
 # To check that file was added in commit any time
 if git status > /dev/null 2>&1 && test -n "$(git log --oneline -- "${base}")"; then
-    file_creation=$(stat $base | awk '/Modify/{print $2, $3}')
+    file_creation=$(stat "$base" | awk "/Modify/{print $2, $3}")
     repo_creation=$(git log --reverse --format="format:%ci" | sed -n 1p)
     current_time=$(date "+%Y-%m-%d %H:%M:%S %z")
     file_creation_timestamp=$(date -d "$file_creation" +%s)

--- a/tests/metrics/test-raf.sh
+++ b/tests/metrics/test-raf.sh
@@ -41,23 +41,37 @@ echo "👍🏻 Didn't fail in non-git directory"
   cd "${tmp}"
   rm -rf ./*
   rm -rf .git
+
   git init --quiet .
   git config user.email 'foo@example.com'
   git config user.name 'Foo'
-  file="temp_file"
-  file2="temp_file1"
-  touch -d "1 second ago" "${file}"
-  git add "${file}"
+
+  file1="temp_file1"
+  file2="temp_file2"
+  file3="temp_file3"
+
+  # File 1
+  touch "${file1}"
+  git add "${file1}"
   git config commit.gpgsign false
   git commit --quiet -m "first"
-  "${LOCAL}/metrics/raf.sh" "${file}" "t1"
-  touch -d "1 second ago" "${file2}"
+  "${LOCAL}/metrics/raf.sh" "${file1}" "t1"
+
+  # File 2
+  touch -d "1 month ago" "${file2}"
   git add "${file2}"
   git commit --quiet -m "second"
   "${LOCAL}/metrics/raf.sh" "${file2}" "t2"
-  "${LOCAL}/metrics/raf.sh" "${file2}" "t3"
-  grep "raf 1.0" "t1" # File is created with repo
-  grep "raf 0.0" "t2" # File a second after repo
-  grep "raf 0.5" "t3" # File created exactly in the middle
+
+  # File 3
+  touch -d "1 year ago" "${file3}"
+  git add "${file3}"
+  git commit --quiet -m "third"
+  "${LOCAL}/metrics/raf.sh" "${file3}" "t3"
+  
+  grep "raf 0" "t1"
+  grep "raf 2678" "t2"
+  grep "raf 31536" "t3"
+
 } > "${stdout}" 2>&1
 echo "👍🏻 Correctly calculated the Relative Age of File"

--- a/tests/metrics/test-raf.sh
+++ b/tests/metrics/test-raf.sh
@@ -56,9 +56,8 @@ echo "👍🏻 Didn't fail in non-git directory"
   git commit --quiet -m "second"
   "${LOCAL}/metrics/raf.sh" "${file2}" "t2"
   "${LOCAL}/metrics/raf.sh" "${file2}" "t3"
-  # The following lines are disabled b/c the test is not stable, see: https://github.com/yegor256/cam/issues/165
-  # grep "raf 1.0" "t1" # File is created with repo
-  # grep "raf 0.0" "t2" # File a second after repo
-  # grep "raf 0.5" "t3" # File created exactly in the middle
+  grep "raf 1.0" "t1" # File is created with repo
+  grep "raf 0.0" "t2" # File a second after repo
+  grep "raf 0.5" "t3" # File created exactly in the middle
 } > "${stdout}" 2>&1
 echo "👍🏻 Correctly calculated the Relative Age of File"

--- a/tests/metrics/test-raf.sh
+++ b/tests/metrics/test-raf.sh
@@ -46,17 +46,15 @@ echo "👍🏻 Didn't fail in non-git directory"
   git config user.name 'Foo'
   file="temp_file"
   file2="temp_file1"
-  touch "${file}"
+  touch -d "1 second ago" "${file}"
   git add "${file}"
   git config commit.gpgsign false
   git commit --quiet -m "first"
   "${LOCAL}/metrics/raf.sh" "${file}" "t1"
-  sleep 1
-  touch "${file2}"
+  touch -d "1 second ago" "${file2}"
   git add "${file2}"
   git commit --quiet -m "second"
   "${LOCAL}/metrics/raf.sh" "${file2}" "t2"
-  sleep 1
   "${LOCAL}/metrics/raf.sh" "${file2}" "t3"
   # The following lines are disabled b/c the test is not stable, see: https://github.com/yegor256/cam/issues/165
   # grep "raf 1.0" "t1" # File is created with repo


### PR DESCRIPTION
According to #165, in `test-raf.sh` file, there was `sleep 1` command, which does not guarantee CPU to sleep exactly 1 second, therefore I removed `sleep` commands, and changed `touch` command, which includes timestamp modification to ensure stability over this test.