### PR TITLE
Fixed test-measure.sh to check suffixes properly and be quiet

### DIFF
--- a/tests/steps/test-measure.sh
+++ b/tests/steps/test-measure.sh
@@ -60,11 +60,9 @@ EOT
         name=${m:3:100}
         
         echo "Checking ${name}..."
-        if echo "${name}" | grep -E '(Mn|Mx|Av)'; then
-            if ! echo "${name}" | grep -E '(Mn|Mx|Av)$'; then
-                echo "Error: ${name} is not correctly formatted."
-                exit 1
-            fi
+        if echo "${name}" | grep -q -E '(.)*(Mn|Mx|Av)(.)+'; then
+            echo "Error: ${name} is not correctly formatted."
+            exit 1
         fi
         echo "${name}" | grep -E '^([A-Z][A-Za-z0-9]*)+(-cvc)?$'
     done


### PR DESCRIPTION
Fixed test-measure.sh to follow the rules: if **Mn**, **Mx** or **Av** is used in the name, it should finish the name. **Before**, it was also possible to have the `(Mn|Mx|Av)` **both** in **the end** and **somewhere else**.