### PR TITLE
Add license filter to discover-repos.rb

### DIFF
--- a/steps/discover-repos.rb
+++ b/steps/discover-repos.rb
@@ -51,7 +51,7 @@ end
 raise 'Can only retrieve up to 1000 repos' if opts[:total] > max
 
 size = [opts[:page_size], opts[:total]].min
-licenses_to_filter = [
+licenses = [
   'mit',
   'apache-2.0',
   '0bsd'
@@ -75,33 +75,33 @@ query = [
   'android'
 ].join(' ')
 
-def mock_array(size, licenses_to_filter)
+def mock_array(size, licenses)
   Array.new(size) do
     {
       full_name: "foo/#{Random.hex(5)}",
       created_at: Time.now,
-      license: { key: licenses_to_filter.sample(1)[0] }
+      license: { key: licenses.sample(1)[0] }
     }
   end
 end
 
-def mock_reps(page, size, licenses_to_filter)
+def mock_reps(page, size, licenses)
   {
     items: if page > 100 then []
     else
-      mock_array(size, licenses_to_filter)
+      mock_array(size, licenses)
     end
   }
 end
 
 loop do
   break if page * size > max
-  json = if opts[:dry] then mock_reps(page, size, licenses_to_filter)
+  json = if opts[:dry] then mock_reps(page, size, licenses)
   else
     github.search_repositories(query, per_page: size, page: page)
   end
   json[:items].each do |i|
-    next if i[:license].nil? || !licenses_to_filter.include?(i[:license][:key])
+    next if i[:license].nil? || !licenses.include?(i[:license][:key])
     found[i[:full_name]] = {
       full_name: i[:full_name],
       default_branch: i[:default_branch],

--- a/steps/discover-repos.rb
+++ b/steps/discover-repos.rb
@@ -52,9 +52,9 @@ raise 'Can only retrieve up to 1000 repos' if opts[:total] > max
 
 size = [opts[:page_size], opts[:total]].min
 licenses_to_filter = [
-  { key: 'mit', name: 'MIT License' },
-  { key: 'apache-2.0', name: 'Apache License 2.0' },
-  { key: '0bsd', name: 'BSD Zero Clause License' }
+  'mit',
+  'apache-2.0',
+  '0bsd'
 ]
 
 github = Octokit::Client.new
@@ -80,7 +80,7 @@ def mock_array(size, licenses_to_filter)
     {
       full_name: "foo/#{Random.hex(5)}",
       created_at: Time.now,
-      license: licenses_to_filter.sample(1)[0]
+      license: { key: licenses_to_filter.sample(1)[0] }
     }
   end
 end
@@ -101,7 +101,7 @@ loop do
     github.search_repositories(query, per_page: size, page: page)
   end
   json[:items].each do |i|
-    next if i[:license].nil? || !licenses_to_filter.include?({ key: i[:license][:key], name: i[:license][:name] })
+    next if i[:license].nil? || !licenses_to_filter.include?(i[:license][:key])
     found[i[:full_name]] = {
       full_name: i[:full_name],
       default_branch: i[:default_branch],


### PR DESCRIPTION
Implemented filtration for repositories with licenses (MIT, Apache 2.0, BSD) as proposed in #275. 

As room for improvement: 
1) Remove hardcoded licenses and let user choose desired licenses to be filtered
2) Add license field to "found" object and export csv/tex files along with license column 