### PR TITLE
fix test-raf on darwin* OS type

### DIFF
--- a/metrics/raf.sh
+++ b/metrics/raf.sh
@@ -29,6 +29,10 @@ output=$(realpath "$2")
 cd "$(dirname "${java}")"
 base=$(basename "${java}")
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    alias gdate=date
+fi
+
 # To check that file was added in commit any time
 if git status > /dev/null 2>&1 && test -n "$(git log --oneline -- "${base}")"; then
     file_creation=$(git log --pretty=format:"%ci" --date=default -- "${base}" | tail -n 1)
@@ -39,7 +43,7 @@ if git status > /dev/null 2>&1 && test -n "$(git log --oneline -- "${base}")"; t
     current_time_timestamp=$(date -d "$current_time" +%s)
     from_file_creation=$((current_time_timestamp - file_creation_timestamp))
     from_repo_creation=$((current_time_timestamp - repo_creation_timestamp))
-    raf=$(echo 'import sys; print(float(sys.argv[1])/float(sys.argv[2]) if float(sys.argv[2]) != 0 else 1.0)' | python3 - $((from_file_creation)) $((from_repo_creation)))
+    raf=$(echo 'import sys; print(round(float(sys.argv[1])/float(sys.argv[2]), 1) if float(sys.argv[2]) != 0 else 1.0)' | python3 - $((from_file_creation)) $((from_repo_creation)))
 else
     raf=0
 fi

--- a/tests/metrics/test-raf.sh
+++ b/tests/metrics/test-raf.sh
@@ -26,6 +26,10 @@ set -o pipefail
 temp=$1
 stdout=$2
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  alias gdate=date
+fi
+
 {
   tmp=$(mktemp -d /tmp/XXXX)
   cd "${tmp}"


### PR DESCRIPTION
I tried to run all tests on my mac os machine and got an issue while test-raf.sh was running - 'date: illegal option -- d'. This is because OSX and Linux use two different sets of tools. We can use gdate command on darwin* OS type instead by using alias.

Later a new problem appeared on the same test - raf.sh does not round the ratio (for example 0.496574 but 0.5 is expected). I decided to fix this within the same commit by simply rounding to the first digit.