### PR TITLE
fix report.bib for linter

### DIFF
--- a/tex/report.bib
+++ b/tex/report.bib
@@ -42,7 +42,7 @@
 @misc{HendersonSellers1996,
   author = {Henderson-Sellers, Brian and Constantine, Larry L. and Graham, Ian M.},
   publisher = {Object Oriented Systems},
-  title = {{Coupling and Cohesion (towards a Valid Metrics Suite for Object-Oriented Analysis and Design)}},
+  title = {{Coupling and Cohesion (Towards a Valid Metrics Suite for Object-Oriented Analysis and Design)}},
   year = {1996},
 }
 


### PR DESCRIPTION
`bibcop` job in github actions seems to be failing. This should fix the problem 