### PR TITLE
fixed error from linter

### DIFF
--- a/steps/discover-repos.rb
+++ b/steps/discover-repos.rb
@@ -71,7 +71,7 @@ query = [
   'is:public',
   'mirror:false',
   'archived:false',
-  'template:false';
+  'template:false',
   'NOT',
   'android'
 ].join(' ')


### PR DESCRIPTION
`make` job in github actions seems to be failing because of ruby lint problem. This should fix the problem