### PR TITLE
Change equality to inequality in floating point numbers comparison (SonarCloud)

### DIFF
--- a/filters/delete-wrong-encoding.py
+++ b/filters/delete-wrong-encoding.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
             encoding = result['encoding']
             confidence = result['confidence']
 
-        if not (encoding in ('ascii', 'UTF-8') and confidence == 1.0):
+        if not (encoding in ('ascii', 'UTF-8') and 1.0 - confidence < 0.01):
             os.remove(java)
             with open(lst, 'a+', encoding='utf-8') as others:
                 others.write(java + "\n")


### PR DESCRIPTION
[`Sonarcloud`](https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&id=yegor256_cam2&open=AY7_zSsbew2BWpcUGRrq) says that it is better to not perform equality for comparison floating point numbers. I suggested solution for this issue