### PR TITLE
Fixed naming for RFVH

### DIFF
--- a/metrics/rfvh.sh
+++ b/metrics/rfvh.sh
@@ -53,4 +53,4 @@ else
     rfvh=0
 fi
 
-echo "rfvh ${rfvh} Relative File Volatility by Hits for file" > "${output}"
+echo "RFVH ${rfvh} Relative File Volatility by Hits for file" > "${output}"

--- a/tests/metrics/test-rfvh.sh
+++ b/tests/metrics/test-rfvh.sh
@@ -53,18 +53,18 @@ stdout=$2
     git add "${java1}"
     git commit --quiet -m "first commit"
     ${metric_script_path} "${java1}" "stdout"
-    grep "rfvh 1" "stdout"
+    grep "RFVH 1" "stdout"
 
     printf "class Foo {}" > "${java2}"
     git add "${java2}"
     git commit --quiet -m "+second commit"
     ${metric_script_path} "${java1}" "stdout"
-    grep "rfvh 0.5" "stdout"
+    grep "RFVH 0.5" "stdout"
 
     printf "class Foo {}" > "${java3}"
     git add "${java3}"
     git commit --quiet -m "-third commit"
     ${metric_script_path} "${java1}" "stdout"
-    grep "rfvh 0.33" "stdout"
+    grep "RFVH 0.33" "stdout"
 } > "${stdout}" 2>&1
 echo "👍🏻 Correctly calculated relative file volatility by hits"


### PR DESCRIPTION
There is a check in `steps/test-measure.sh`. It ensures that every metric is named properly (More specifically, abbreviation of metric inside output of metric) in convention named `AllCaps`. There was a problem with the RFVC metric that couldn't pass checks because the name of the metric was not specified correctly. However, for RFVH, the name was written in the same way as for RFVC, but for some reason it passed. Thus, this fix is created to avoid further problems with RFVH metric