### PR TITLE
feat(#227): samples-filter integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ multimetric==1.3.0
 chardet==5.2.0
 mypy==1.10.0
 cffconvert==2.0.0
+samples-filter==0.4.1

--- a/steps/discover.sh
+++ b/steps/discover.sh
@@ -60,6 +60,15 @@ elif [ -z "${REPOS}" ] || [ ! -e "${REPOS}" ]; then
   fi
   "${LOCAL}/help/assert-tool.sh" ruby -v
   ruby "${LOCAL}/steps/discover-repos.rb" "${args[@]}"
+  nosamples=${TARGET}/no-samples.csv
+  declare -a fargs=( \
+    "--repositories=${csv}" \
+    "--out=${nosamples}" \
+    "--model=transformer"
+  )
+  python3 -m samples-filter filter "${fargs[@]}"
+  rm "${csv}"
+  mv "${nosamples}" "${csv}"
 else
   echo "Using the list of repositories from the '${REPOS}' file (defined by the REPOS environment variable)..."
   cat "${REPOS}" > "${csv}"

--- a/steps/discover.sh
+++ b/steps/discover.sh
@@ -66,7 +66,7 @@ elif [ -z "${REPOS}" ] || [ ! -e "${REPOS}" ]; then
     "--out=${nosamples}" \
     "--model=transformer"
   )
-  python3 -m samples-filter filter "${fargs[@]}"
+  samples-filter filter "${fargs[@]}"
   rm "${csv}"
   mv "${nosamples}" "${csv}"
 else


### PR DESCRIPTION
@yegor256, take a look, please

I've developed [samples-filter](https://github.com/h1alexbel/samples-filter) command-line tool for filtering `repositories.csv`. We support both models: ML model based on [Random-Forest](https://en.wikipedia.org/wiki/Random_forest) algorithm, and [Transformer](https://en.wikipedia.org/wiki/Transformer_(deep_learning_architecture)) model. We trained them on dataset of descriptions and READMEs of public GitHub repositories. In this pr, I've introduced integration with that tool by using `transformer` model. Let's see how it will perform on filtering by repos description.

closes #227