### PR TITLE
Fix command in README.md with sudo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Then, run the entire test suite
 
 ```bash
 sudo make install
-make test lint
+sudo make test lint
 ```
 
 Then, send us a


### PR DESCRIPTION
Sometimes it can cause 

`
before/test-executability.sh:
rm: cannot remove '/home/user/develop/cam/test-zone/before/test-executability.sh/target': Permission denied
make: *** [Makefile:78: test] Error 1
`