### PR TITLE
Change for pip3

### DIFF
--- a/installs/install-pip.sh
+++ b/installs/install-pip.sh
@@ -25,7 +25,7 @@ set -e
 set -o pipefail
 
 "${LOCAL}/help/assert-tool.sh" python3 --version
-"${LOCAL}/help/assert-tool.sh" pip --version
+"${LOCAL}/help/assert-tool.sh" pip3 --version
 
 "${LOCAL}/help/sudo.sh" python3 -m pip install --upgrade pip
 "${LOCAL}/help/sudo.sh" python3 -m pip install -r "${LOCAL}/requirements.txt"


### PR DESCRIPTION
@yegor256 

While installing python3 - we need to use pip3, not pip

So I suggest changing check to pip3 while install-pip.sh