### PR TITLE
Added python code linter to Github Actions

### DIFF
--- a/.github/workflows/python-flake8-lint.yml
+++ b/.github/workflows/python-flake8-lint.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Install dependencies

--- a/.github/workflows/python-flake8-lint.yml
+++ b/.github/workflows/python-flake8-lint.yml
@@ -1,0 +1,26 @@
+name: Python-Flake8-Linter
+
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  flake8:
+    name: Flake8
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: pip install flake8
+      - name: Run Flake8
+        run: |
+          flake8 --max-line-length=120 .

--- a/metrics/ast.py
+++ b/metrics/ast.py
@@ -29,7 +29,7 @@ import javalang
 
 
 def doer(tlist: list[tuple[Any, javalang.tree.ClassDeclaration]]) -> float:
-    """Ratio between the number of attributes that are data primitives and the number of attributes that are pointers to objects.
+    """Ratio of the quantity of attributes that are data primitives and those that are pointers to objects.
     :rtype: float
     """
     declaration = tlist[0][1].filter(javalang.tree.FieldDeclaration)

--- a/metrics/cyclomatic_complexity.py
+++ b/metrics/cyclomatic_complexity.py
@@ -38,7 +38,16 @@ def branches(parser_class: tree.CompilationUnit) -> int:
     if isinstance(parser_class, tree.BinaryOperation):
         if parser_class.operator in ('&&', '||'):
             count = 1
-    elif (isinstance(parser_class, (tree.ForStatement, tree.IfStatement, tree.WhileStatement, tree.DoStatement, tree.TernaryExpression))):
+    elif isinstance(
+        parser_class,
+        (
+            tree.ForStatement,
+            tree.IfStatement,
+            tree.WhileStatement,
+            tree.DoStatement,
+            tree.TernaryExpression
+        )
+    ):
         count = 1
     elif isinstance(parser_class, tree.SwitchStatementCase):
         count = 1


### PR DESCRIPTION
@yegor256 
In order to improve code support inside the repository, Python linter has been added as the new GitHub Actions workflow.
For the convenience of working inside the Jetbrains IDE set, an additional flag --max-line-length=120 was added, since this value is the default for the built-in PyCharm linter.
Check, please