### PR TITLE
Add path export of tlmgr for macOS

### DIFF
--- a/help/is-macos.sh
+++ b/help/is-macos.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# The MIT License (MIT)
+#
+# Copyright (c) 2021-2024 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+set -e
+set -o pipefail
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/installs/install-texlive.sh
+++ b/installs/install-texlive.sh
@@ -38,7 +38,7 @@ if ! "${LOCAL}/help/texlive-bin.sh"; then
 fi
 
 if ! tlmgr --version >/dev/null 2>&1; then
-  if "${LOCAL}/help/is-linux.sh"; then
+  if "${LOCAL}/help/is-linux.sh" || "${LOCAL}/help/is-macos.sh"; then
     PATH=$PATH:$("${LOCAL}/help/texlive-bin.sh")
     export PATH
   else


### PR DESCRIPTION
@yegor256 
In this PR I fixed problem #338, because we need export PATH of `tlmgr` in macOS

Now on macOS we can complete all install steps

<img width="668" alt="Screenshot 2024-05-24 at 01 28 38" src="https://github.com/yegor256/cam/assets/64702874/a4bd9b5b-4723-4e9e-bcf3-ecc6c9cadfb7">
