### PR TITLE
Add the specific contribution steps in order in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,23 +109,17 @@ make REPO=yegor256/tojos
 
 ## How to Contribute (e.g. by adding a new metric)
 
-If you want to add a new metric to the script, fork a repository and
-create a new file in the `metrics/` directory, using one of
-the existing files as an example.
-Then, create a test for your metric, in the `tests/metrics/` directory.
+For example, you want to add a new metric to the script:
 
-Then, run the entire test suite
-(this should take a few minutes to complete, without errors):
+1. Fork a repository.
+2. Create a new file in the `metrics/` directory, using one of the existing files as an example.
+3. Create a test for your metric, in the `tests/metrics/` directory.
+4. Run the entire test suite (this should take a few minutes to complete, without errors):
 
 ```bash
 sudo make install
-make test lint
+sudo make test lint
 ```
-
-Then, send us a
-[pull request](https://www.yegor256.com/2014/04/15/github-guidelines.html).
-We will review your changes and apply them to the `master` branch shortly,
-provided they don't violate our quality standards.
 
 You can also test it with Docker:
 
@@ -140,6 +134,10 @@ if you don't change any installation scripts:
 ```bash
 docker run -v $(pwd):/c --rm yegor256/cam:0.9.2 make -C /c test
 ```
+
+5. Send us a [pull request](https://www.yegor256.com/2014/04/15/github-guidelines.html). 
+We will review your changes and apply them to the `master` branch shortly,
+provided they don't violate our quality standards.
 
 ## How to Calculate Additional Metrics
 


### PR DESCRIPTION
At the moment, the section "how to contribute" is made in solid text. It is much easier to read this if you write down all the steps in an ordered list, so I edited the README a little.