### PR TITLE
#308 put CaM sources into zip archive

### DIFF
--- a/steps/zip.sh
+++ b/steps/zip.sh
@@ -36,6 +36,12 @@ if [ -e "${zip}" ]; then
     exit
 fi
 
+cam_repo_target_dir="${TARGET}/github/self/${name}"
+
+if [ ! -d "${cam_repo_target_dir}" ]; then
+    git clone --depth 1 https://github.com/yegor256/cam.git "${cam_repo_target_dir}"
+fi
+
 if [ -e "${TARGET}/github" ]; then
     echo "Deleting .git directories (may take some time) ..."
     find "${TARGET}/github" -maxdepth 3 -mindepth 3 -type d -name '.git' -exec rm -rf {} \;

--- a/steps/zip.sh
+++ b/steps/zip.sh
@@ -36,10 +36,11 @@ if [ -e "${zip}" ]; then
     exit
 fi
 
-cam_repo_target_dir="${TARGET}/github/self/${name}"
+cam_repo_target_dir="${TARGET}/cam-sources"
 
 if [ ! -d "${cam_repo_target_dir}" ]; then
     git clone --depth 1 https://github.com/yegor256/cam.git "${cam_repo_target_dir}"
+    rm -rf "${cam_repo_target_dir}/.git"
 fi
 
 if [ -e "${TARGET}/github" ]; then

--- a/tests/after/test-integration.sh
+++ b/tests/after/test-integration.sh
@@ -46,7 +46,7 @@ stdout=$2
     for f in start.txt hashes.csv report.pdf repositories.csv; do
         test -f "${TARGET}/${f}"
     done
-    test "$(find "${TARGET}" -maxdepth 1 | wc -l | xargs)" = 10
+    test "$(find "${TARGET}" -maxdepth 1 | wc -l | xargs)" = 11
     test -f "${TARGET}/data/${repo}/NCSS.csv"
     test -f "${TARGET}/data/${repo}/NHD.csv"
     test -f "${TARGET}/data/${repo}/SCOM-cvc.csv"

--- a/tests/steps/test-zip.sh
+++ b/tests/steps/test-zip.sh
@@ -37,9 +37,10 @@ echo "👍🏻 A zip archive generated correctly"
     zip=${TARGET}/cam-$(date +%Y-%m-%d).zip
     "${LOCAL}/steps/zip.sh"
     list=$(unzip -l "${zip}")
-    echo "${list}" | grep "cam-*/" > /dev/null
+    echo "${list}" | grep "cam-sources/" > /dev/null
+    echo "${list}" | grep --invert-match "cam-sources/.git" > /dev/null
 } > "${stdout}" 2>&1
-echo "👍🏻 A zip archive contains the CaM repository"
+echo "👍🏻 A zip archive contains the CaM repository (without .git)"
 
 {
     mkdir -p "${TARGET}/measurements/a/b/baam.m.cloc"

--- a/tests/steps/test-zip.sh
+++ b/tests/steps/test-zip.sh
@@ -33,6 +33,15 @@ stdout=$2
 echo "👍🏻 A zip archive generated correctly"
 
 {
+    mkdir -p "${TARGET}/something"
+    zip=${TARGET}/cam-$(date +%Y-%m-%d).zip
+    "${LOCAL}/steps/zip.sh"
+    list=$(unzip -l "${zip}")
+    echo "${list}" | grep "cam-*/" > /dev/null
+} > "${stdout}" 2>&1
+echo "👍🏻 A zip archive contains the CaM repository"
+
+{
     mkdir -p "${TARGET}/measurements/a/b/baam.m.cloc"
     mkdir -p "${TARGET}/temp/a/b/hello.txt"
     zip=${TARGET}/cam-$(date +%Y-%m-%d).zip


### PR DESCRIPTION
Work under #308: Adding CaM sources to a zip archive.

Some notes:

- The path to clone the repo is `${TARGET}/github/self/${name}` to use a common command for all repos, removing the `.git` directories. 
- A user may be using an out-of-date version of CaM, in which case they will keep an archive with a CaM repo of a newer version. 