### PR TITLE
Data races in aggregate-repo.sh step

### DIFF
--- a/steps/aggregate-repo.sh
+++ b/steps/aggregate-repo.sh
@@ -61,7 +61,8 @@ find "${dir}" -type f -name '*.m' > "${mfiles}"
 sum=0
 declare -i files=0
 while IFS= read -r m; do
-    slice=${TARGET}/temp/mfiles-slice.txt
+    slice=${TARGET}/temp/mfiles-slice/${repo}.txt
+    mkdir -p "$(dirname "${slice}")"
     find "$(dirname "${m}")" -name "$(basename "${m}").*" -type f -print > "${slice}"
     while IFS= read -r v; do
         java=$(echo "${v}" | sed "s|${dir}||" | sed "s|\.m\..*$||")


### PR DESCRIPTION
Running the aggregate-repo.sh script in parallel for each file [here](https://github.com/yegor256/cam/blob/811011bac90c7d3a68852295aa5e375d5f409fe7/steps/aggregate.sh#L47) causes a data race when accessing the `temp/mfiles-slice` file [here](https://github.com/yegor256/cam/blob/811011bac90c7d3a68852295aa5e375d5f409fe7/steps/aggregate-repo.sh#L64), which results in aggregation failures.