### PR TITLE
Fix bib cop linter

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -31,6 +31,7 @@ path = [
     ".DS_Store",
     ".dockerignore",
     ".gitattributes",
+    ".gitmodules",
     ".gitignore",
     ".latexmkrc",
     ".shellcheckrc",

--- a/steps/lint.sh
+++ b/steps/lint.sh
@@ -30,7 +30,6 @@ if ! bibcop --version >/dev/null 2>&1; then
   PATH=$PATH:$("${LOCAL}/help/texlive-bin.sh")
   export PATH
 fi
-bibcop tex/report.bib
 
 while IFS= read -r sh; do
     shellcheck --shell=bash --severity=style "${sh}"


### PR DESCRIPTION
Updated:
- As new file was added in prev commit named gitmodule, it was added to reuse exception;
- Deleted reference to deleted file report.bib.

Resolves: https://github.com/yegor256/cam/issues/427