### PR TITLE
#436: fix test-raf.sh not working

### DIFF
--- a/tests/metrics/test-raf.sh
+++ b/tests/metrics/test-raf.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2021-2025 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
-# shellcheck disable=SC2317
 set -e -o pipefail
 
 temp=$1
@@ -18,6 +17,7 @@ stdout=$2
 echo "👍🏻 Didn't fail in non-git directory"
 
 {
+  # shellcheck source=../../help/gnu-utils.sh disable=SC1091
   source "${LOCAL}/help/gnu-utils.sh"
   tmp=$(mktemp -d /tmp/XXXX)
   cd "${tmp}"


### PR DESCRIPTION
On systems with Russian locale, date returned localized output that Git couldn’t parse. Forced English format using LC_ALL=C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed an early-exit guard so the test now runs to completion.
  * Ensured helper utilities are loaded during the test.
  * Made commit date generation locale-deterministic to produce consistent, reproducible results across environments.
  * Improves test reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->