### PR TITLE
Skip Sonar scan when SONAR_TOKEN is missing

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,12 +13,13 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - if: ${{ secrets.SONAR_TOKEN != '' }}
+      - if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: SonarSource/sonarqube-scan-action@master
+      - if: ${{ secrets.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Fixes #475 (workaround).

The workflow currently fails when SONAR_TOKEN is missing/invalid.
This PR adds a guard so the Sonar scan step runs only when SONAR_TOKEN is present.

This prevents noisy CI failures while keeping Sonar enabled when configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to expose scanning credentials at the job level.
  * Code-quality scan step now runs conditionally only when credentials are present, preventing unnecessary scan executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->