### PR TITLE
chore(deps): bump pylint, mypy, flake8 and typos action

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.40.0
+      - uses: crate-ci/typos@v1.45.1
         with:
           config: ./typos_config.toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 javalang==0.13.0
-flake8==7.0.0
-pylint==4.0.4
+flake8==7.3.0
+pylint==4.0.5
 multimetric==1.3.0
 chardet==5.2.0
-mypy==1.12.1
+mypy==1.20.2
 cffconvert==2.0.0
 samples-filter==0.5.1


### PR DESCRIPTION
- pylint 4.0.4 -> 4.0.5 (renovate PR #492 green)
- mypy 1.12.1 -> 1.20.2 (renovate PR #390 green)
- flake8 7.0.0 -> 7.3.0 (renovate PR #349)
- crate-ci/typos action v1.40.0 -> v1.45.1 (renovate PR #488 green)

https://claude.ai/code/session_01KeKuL1sPJ5UqJqp8Lv55QN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to their latest stable versions for improved code quality assurance.
  * Updated automated code quality checks to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->