### PR TITLE
#232 raise nofile soft limit in help/parallel.sh to silence GNU parallel

### DIFF
--- a/help/parallel.sh
+++ b/help/parallel.sh
@@ -9,6 +9,13 @@ if [ -z "${x}" ]; then
   x=1;
 fi
 
+# Raise the open-file soft limit to the hard limit so that GNU parallel
+# does not print "Only enough file handles to run N jobs in parallel".
+hard=$(ulimit -Hn 2>/dev/null || echo "")
+if [ -n "${hard}" ] && [ "${hard}" != "unlimited" ]; then
+  ulimit -n "${hard}" 2>/dev/null || true
+fi
+
 cores=$(echo "$(nproc) * ${x}" | bc)
 args=(
   '--halt-on-error=now,fail=1'


### PR DESCRIPTION
Closes #232.

`help/parallel.sh` now raises the open-file soft limit to the hard limit before invoking GNU parallel. With the soft limit raised, parallel no longer prints `Only enough file handles to run N jobs in parallel` and the two follow-up `Warning: Try running ...` lines, so the make output during the clone step is clean.

Checked locally: `bash -n help/parallel.sh` parses, `shellcheck --shell=bash --severity=style help/parallel.sh` passes with no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved file handle limit warnings that appeared during parallel processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->